### PR TITLE
feat(authorization): 添加团队成员 ID 并更新相关功能

### DIFF
--- a/src/api/authorization/index.ts
+++ b/src/api/authorization/index.ts
@@ -182,6 +182,10 @@ export interface RefreshTokenReply {
    * 团队ID
    */
   teamID?: number
+  /**
+   * 团队成员ID
+   */
+  teamMemberID: number
 }
 
 /**

--- a/src/api/request.ts
+++ b/src/api/request.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { message, notification } from 'antd'
 import axios, { type AxiosError, type AxiosRequestConfig } from 'axios'
+import { TeamItem } from './model-types'
 
 const host = window.location.origin
 
@@ -58,12 +59,22 @@ request.interceptors.request.use(
   (config) => {
     const token = getToken()
     config.headers['Authorization'] = `Bearer ${token}`
+    config.headers['X-Team-ID'] = getTeamInfo()?.id
+    config.headers['X-Team-Member-ID'] = getTeamMemberID()
     return config
   },
   (error) => {
     return Promise.reject(error)
   }
 )
+
+export const getTeamInfo = (): TeamItem => {
+  return JSON.parse(localStorage.getItem('teamInfo') || '{"id":0}')
+}
+
+export const getTeamMemberID = () => {
+  return +(localStorage.getItem('teamMemberID') || '0')
+}
 
 export const setToken = (token: string) => {
   sessionStorage.setItem('token', token)
@@ -163,7 +174,7 @@ const errorHandle = (err: ErrorResponse) => {
 export const buildHeader = (isSystem?: boolean) => {
   return {
     headers: {
-      'Source-Type': isSystem ? 'System' : 'Team'
+      'X-Source-Type': isSystem ? 'System' : 'Team'
     }
   }
 }

--- a/src/components/layout/team-menu.tsx
+++ b/src/components/layout/team-menu.tsx
@@ -19,14 +19,15 @@ function getTeamInfo() {
 
 export const TeamMenu: React.FC = () => {
   const createTeamContext = useCreateTeamModal()
-  const { teamInfo, setTeamInfo, setUserInfo, refreshMyTeamList } = useContext(GlobalContext)
+  const { teamInfo, setTeamInfo, setUserInfo, refreshMyTeamList, setTeamMemberID } = useContext(GlobalContext)
   const [teamList, setTeamList] = React.useState<TeamItem[]>([])
 
   const { run: initRefreshToken } = useRequest(refreshToken, {
     manual: true,
-    onSuccess: ({ token, user }) => {
+    onSuccess: ({ token, user, teamMemberID }) => {
       setToken(token)
       setUserInfo?.(user)
+      setTeamMemberID?.(teamMemberID)
     }
   })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -33,6 +33,7 @@ function App() {
   const [collapsed, setCollapsed] = useStorage<boolean>('collapsed', false)
   const [userInfo, setUserInfo] = useStorage<UserItem>('userInfo', getUserInfo())
   const [teamInfo, setTeamInfo, removeTeamInfo] = useStorage<TeamItem>('teamInfo', undefined)
+  const [teamMemberID, setTeamMemberID, removeTeamMemberID] = useStorage<number>('teamMemberID', 0)
   const [refreshMyTeamList, setRefreshMyTeamList] = useState<boolean>(false)
   const [localURL, setLocalURL] = useStorage<string>('localURL', localStorage.getItem('localURL') || '/')
   const [showLevelColor, setShowLevelColor] = useStorage<boolean>('showLevelColor', false)
@@ -56,6 +57,9 @@ function App() {
     teamInfo: teamInfo,
     setTeamInfo: setTeamInfo,
     removeTeamInfo: removeTeamInfo,
+    teamMemberID: teamMemberID,
+    setTeamMemberID: setTeamMemberID,
+    removeTeamMemberID: removeTeamMemberID,
     refreshMyTeamList: refreshMyTeamList,
     setRefreshMyTeamList: () => setRefreshMyTeamList(!refreshMyTeamList),
     isFullscreen: isFullscreen,

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -25,6 +25,9 @@ export type GlobalContextType = {
   teamInfo?: TeamItem
   setTeamInfo?: (teamInfo: TeamItem) => void
   removeTeamInfo?: () => void
+  teamMemberID?: number
+  setTeamMemberID?: (teamMemberID: number) => void
+  removeTeamMemberID?: () => void
   refreshMyTeamList?: boolean
   setRefreshMyTeamList?: () => void
   isFullscreen?: boolean


### PR DESCRIPTION
- 在 RefreshTokenReply 接口中添加 teamMemberID 字段
- 在请求拦截器中添加 X-Team-ID 和 X-Team-Member-ID 头
- 实现 getTeamInfo 和 getTeamMemberID 方法
- 更新 TeamMenu 组件以使用 teamMemberID
- 在全局上下文中添加 teamMemberID 相关状态
- 修改首页以存储和使用 teamMemberID